### PR TITLE
Add reset method to CollectorRegistry and MetricWrapperBase

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -73,6 +73,14 @@ class MetricWrapperBase(object):
             metric.add_sample(self._name + suffix, labels, value)
         return [metric]
 
+    def reset(self):
+        if self._is_parent():
+            with self._lock:
+                for labels, metric in self._metrics.items():
+                    metric.reset()
+        elif self._is_observable():
+            self._metric_init()
+
     def __init__(self,
                  name,
                  documentation,

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -75,6 +75,16 @@ class CollectorRegistry(object):
             for metric in collector.collect():
                 yield metric
 
+    def reset(self):
+        """Clears value for each metric in each collector in the registry."""
+        collectors = None
+        with self._lock:
+            collectors = self._collector_to_names
+            for collector in collectors:
+                if hasattr(collector, 'reset'):
+                    collector.reset()
+
+
     def restricted_registry(self, names):
         """Returns object that only collects some metrics.
 


### PR DESCRIPTION
The reset method sets the metric values back to their initial state. This enables workflows like pushing values to an external aggregator.

Further development is needed before I could think about merging upstream
- This code has not been proven to be thread safe yet, additional tests are needed to confirm.
- Additional and more targeted unit tests
- `hasattr(collector, 'reset')` feels bad, It seems possible there is a better solution, but I"m not sure.
- mulitprocess mode
- set up CI and duplicate if this will be a long running fork

I ran the tests against Python 3.6 using `tox -e py36` and tested end to end via
- this PR in the metrics library: https://github.com/textioHQ/metrics-client-py/compare/topic-add-lambda-decorator#diff-45d8c9f266edf8ae9d393ae0d3284e0aR6
- this PR in the bulk import service: https://github.com/textioHQ/textio-bulk-import/compare/topic-add-metrics#diff-74781882afb03ddb0c2f76bd57dfa82aR28

The dashboard form the test is
https://metrics-predev.int.textio.tech/d/xXYUXQvWk/bulk-import-forked-library-test?orgId=1